### PR TITLE
Functionality to allow for FadeJs rendering to have a maximum opacity setting

### DIFF
--- a/blur.js
+++ b/blur.js
@@ -1,3 +1,14 @@
+function opacityFactor (opacity, f) {
+    return ((+opacity * f)).toString();
+}
+function getOpacityAttr(el) {
+    let opacity = '1';
+    let _originalOpacity_ = el.outerHTML.match(/(?<=fadejs-data="opacity:).(([0-9]\d*(\.\d+)?;)|([0-9]\d*(\.\d+)?"))/gm);
+    if (_originalOpacity_ && _originalOpacity_.length > 0) {
+        opacity = _originalOpacity_[0].slice(0, _originalOpacity_[0].length - 1).replace(/opacity:/, '');
+        opacity = (+opacity / 2).toFixed(2).toString();
+    } return opacity;
+}
 function whenDone(){
     var x = document.getElementsByClassName("blurjs");
     var i;
@@ -26,10 +37,11 @@ function whenDone(){
             var r;
             for (r = 0; r < y.length; r++) {
                 if(y[r].className.search("fadejs") >= 0){
-                    var justTemp_1 = y[r].outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:1;' class=");
-                    var justTemp_2 = y[r].outerHTML.replace(/class=/, "style='animation-delay:20ms;opacity:.75;' class=");
-                    var justTemp_3 = y[r].outerHTML.replace(/class=/, "style='animation-delay:40ms;opacity:.5;' class=");
-                    var justTemp_4 = y[r].outerHTML.replace(/class=/, "style='animation-delay:60ms;opacity:.25;' class=");
+                    let opacity = getOpacityAttr(y[r]);
+                    var justTemp_1 = y[r].outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:" + opacityFactor(opacity, 1) + ";' class=");
+                    var justTemp_2 = y[r].outerHTML.replace(/class=/, "style='animation-delay:20ms;opacity:" + opacityFactor(opacity, .75) + ";' class=");
+                    var justTemp_3 = y[r].outerHTML.replace(/class=/, "style='animation-delay:40ms;opacity:" + opacityFactor(opacity, .5) + ";' class=");
+                    var justTemp_4 = y[r].outerHTML.replace(/class=/, "style='animation-delay:60ms;opacity:" + opacityFactor(opacity, .25) + ";' class=");
                     y[r].outerHTML = justTemp_4+justTemp_3+justTemp_2+justTemp_1;
                     r += 3;
                 }
@@ -51,9 +63,10 @@ function blurMe(e){
 function fadeMe(e){
     var c = e.target.parentNode;
     c.getElementsByTagName("img")[0].outerHTML="";
-    var justTemp_1 = c.outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:1;' class=");
-    var justTemp_2 = c.outerHTML.replace(/class=/, "style='animation-delay:20ms;opacity:.75;' class=");
-    var justTemp_3 = c.outerHTML.replace(/class=/, "style='animation-delay:40ms;opacity:.5;' class=");
-    var justTemp_4 = c.outerHTML.replace(/class=/, "style='animation-delay:60ms;opacity:.25;' class=");
+    let opacity = getOpacityAttr(y[r]);
+    var justTemp_1 = c.outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:" + opacityFactor(opacity, 1) + ";' class=");
+    var justTemp_2 = c.outerHTML.replace(/class=/, "style='animation-delay:20ms;opacity:" + opacityFactor(opacity, .75) + ";' class=");
+    var justTemp_3 = c.outerHTML.replace(/class=/, "style='animation-delay:40ms;opacity:" + opacityFactor(opacity, .5) + ";' class=");
+    var justTemp_4 = c.outerHTML.replace(/class=/, "style='animation-delay:60ms;opacity:" + opacityFactor(opacity, .25) + ";' class=");
     c.outerHTML = justTemp_4+justTemp_3+justTemp_2+justTemp_1;
 }

--- a/blur.js
+++ b/blur.js
@@ -1,14 +1,51 @@
 function opacityFactor (opacity, f) {
     return ((+opacity * f)).toString();
 }
-function getOpacityAttr(el) {
+
+function getTrueOpacity(el) {
     let opacity = '1';
-    let _originalOpacity_ = el.outerHTML.match(/(?<=fadejs-data="opacity:).(([0-9]\d*(\.\d+)?;)|([0-9]\d*(\.\d+)?"))/gm);
+    let specialOpacity = '1';
+    let _originalOpacity_ = el.outerHTML.match(/((?<=fadejs-data="opacity:)|(?<=fadejs-data="opacity: ))(([0-9]\d*(\.\d+)?;)|([0-9]\d*(\.\d+)?"))/gm);
     if (_originalOpacity_ && _originalOpacity_.length > 0) {
         opacity = _originalOpacity_[0].slice(0, _originalOpacity_[0].length - 1).replace(/opacity:/, '');
-        opacity = (+opacity / 2).toFixed(2).toString();
-    } return opacity;
+        specialOpacity = getSpecialOpacityFactor(opacity).toFixed(4).toString();
+        opacity = (+opacity / 1.80555555).toFixed(8).toString(); //1.857142
+    } return [opacity, specialOpacity];
 }
+
+function getSpecialOpacityFactor(x) {
+    x = Math.abs(+x);
+    if (x < 1) {
+
+        if (x < .01) {
+            return 0;
+        } else if (x >= .01 && x <= .05) {
+            return .01;
+        } else if (x > .05 && x <= .2) {
+            return (13.3333 * Math.pow(x, 3) - 6 * Math.pow(x, 2) + 1.06667 * x - 0.03);
+        } else if (x > .2 && x < .3) {
+            if (x <= .28) {
+                return (465029.7619 * Math.pow(x, 5) - 554650.2976 * Math.pow(x, 4) + 263229.1667 * Math.pow(x, 3) - 62118.6756 * Math.pow(x, 2) + 7287.7232 * x - 339.917);
+            } else { return .09; }
+        } else if (x >= .3 && x < .4) {
+            if (x >= .32) {
+                return (9375 * Math.pow(x, 4) - 13229.2 * Math.pow(x, 3) + 6987.5 * Math.pow(x, 2) - 1636.58 * x + 143.466);
+            } else { return .09; }
+        } else if (x >= .4 && x < .55) {
+            return (-24.2424 * Math.pow(x, 3) + 35.8182 * Math.pow(x, 2) - 16.7485 * x + 2.67);
+        } else if (x >= .55 && x < .6) {
+            return (1.2 * x - 0.4);
+        } else if (x >= .6 && x < .65) {
+            return 0.6 * x - 0.039999999999999;
+        } else if (x >= .65 && x < .85) {
+            return (-13.3333 * Math.pow(x, 3) + 30 * Math.pow(x, 2) - 20.8667 * x + 4.9);
+        } else if (x >= .85) {
+            return (-26.1905 * Math.pow(x, 3) + 72.7143 * Math.pow(x, 2) - 64.8774 * x + 19.3439);
+        }
+
+    } else { return x > 0 ? 1 : 0; }
+}
+
 function whenDone(){
     var x = document.getElementsByClassName("blurjs");
     var i;
@@ -29,6 +66,7 @@ function whenDone(){
             window.runScriptA = 1;
         }    
     }
+
     var x = document.getElementsByClassName("fadejs");
     var i;
     for (i = 0; i < x.length; i++) {
@@ -37,8 +75,10 @@ function whenDone(){
             var r;
             for (r = 0; r < y.length; r++) {
                 if(y[r].className.search("fadejs") >= 0){
-                    let opacity = getOpacityAttr(y[r]);
-                    var justTemp_1 = y[r].outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:" + opacityFactor(opacity, 1) + ";' class=");
+                    let opacityValues = getTrueOpacity(y[r]);
+                    let opacity = opacityValues[0];
+                    let specialOpacity = opacityValues[1];
+                    var justTemp_1 = y[r].outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:" + specialOpacity + ";' class=");
                     var justTemp_2 = y[r].outerHTML.replace(/class=/, "style='animation-delay:20ms;opacity:" + opacityFactor(opacity, .75) + ";' class=");
                     var justTemp_3 = y[r].outerHTML.replace(/class=/, "style='animation-delay:40ms;opacity:" + opacityFactor(opacity, .5) + ";' class=");
                     var justTemp_4 = y[r].outerHTML.replace(/class=/, "style='animation-delay:60ms;opacity:" + opacityFactor(opacity, .25) + ";' class=");
@@ -50,7 +90,9 @@ function whenDone(){
         }
     }
 }
+
 document.addEventListener("DOMContentLoaded", whenDone);
+
 function blurMe(e){
     var c = e.target.parentNode;
     c.getElementsByTagName("img")[0].outerHTML="";
@@ -63,8 +105,12 @@ function blurMe(e){
 function fadeMe(e){
     var c = e.target.parentNode;
     c.getElementsByTagName("img")[0].outerHTML="";
-    let opacity = getOpacityAttr(y[r]);
-    var justTemp_1 = c.outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:" + opacityFactor(opacity, 1) + ";' class=");
+
+    let opacityValues = getTrueOpacity(y[r]);
+    let opacity = opacityValues[0];
+    let specialOpacity = opacityValues[1];
+
+    var justTemp_1 = c.outerHTML.replace(/class=/, "style='animation-delay:0ms;opacity:" + specialOpacity + ";' class=");
     var justTemp_2 = c.outerHTML.replace(/class=/, "style='animation-delay:20ms;opacity:" + opacityFactor(opacity, .75) + ";' class=");
     var justTemp_3 = c.outerHTML.replace(/class=/, "style='animation-delay:40ms;opacity:" + opacityFactor(opacity, .5) + ";' class=");
     var justTemp_4 = c.outerHTML.replace(/class=/, "style='animation-delay:60ms;opacity:" + opacityFactor(opacity, .25) + ";' class=");


### PR DESCRIPTION
Hello, Adir-SL, I hope this Pull Request finds you well 😄

I recently came across your module here, and thought it was really cool! However, it wasn't working with my project, as I wanted to use it on elements that had various opacity levels. Thus, I have solved the problem by adding optional functionality for setting the maximum opacity used by the fadejs rendering.

**Problem**:

Currently, when using the "fadejs" rendering, if the target element also has a stylesheet class that sets it's opacity below 100%, the fadejs rendering will make the element appear as if it were set to 100%.

**Solution**:

I Added logic that can extract a custom html tag attribute, "**fadejs-data**", that a page can use to define an element's maximum opacity. Then, the algorithm in place will allow the cascaded fadejs rendered element's opacity to match the intended opacity for the element, while still having the same effect, to scale. 

The algorithm used is a branching algorithm containing several polynomials generated via Lagrange Interpolation after taking precise measurements by the thousandth decimal place for the "correct value", after using a baseline formula for all 4 rendered fadejs elements: [f(x) = x / 1.805555555, f2(x) = .75f(x), f3(x) = .5f(x), f4(x) = .25f(x)].

**Usage**:

The attribute is added to a tag like so (a leading 0 is required, but the semicolon and space is not):
```html
<div id="someDivElement" class="fadejs someOtherStyle" fadejs-data="opacity: 0.65;"/>
```

It uses a value of 1 by default (if the attribute is missing from the tag or the value exceeds 1), which will emulate the same behavior as fadejs currently has (making this feature optional and non-breaking).

**Impact**:

I have not benchmarked performance at all. I would imagine it's very minimal. I used a branching algorithm to make this calculation as efficient as possible. Obviously this increases the file size of the *.js file quite a bit, relatively.. Perhaps a minified *.js could be provided to negate the impact in terms of file-size.

**A Note on Opacity Animations**:

One other important thing to note: When the fadejs class is used, even with a maximum opacity set, any CSS "from-to" keyframe animations involving setting the opacity will still not work as intended, and will have a severe flicker effect. However, a working solution is to do something like this:

Assume that 0.65 is my intended opacity. First, I get the "maximum" opacity of the animation as 0.1875. I get this using this formula: y = (x + 0.1) / 4. Next, you set the animation to cap out at 25%. Then, you increase the speed of your animation using the formula: y = 12x . So, in this instance, I initially wanted the animation to fade from 0 - .65 opacity in .5s. Using the following combination of keyframe animations will accomplish this, with the Fadejs effect on the transform animation!!
```css
.myAnimationClass {
	visibility: hidden;

	transition: all 0.5s ease !important;
	animation:  0.5s ease 0.25s 1 slideIn, 6s 0s 1 fadeIn;
	animation-fill-mode: forwards;
}

@keyframes slideIn {
	from { transform: translateX(250px); }
	to { transform: translateX(0); }
}

@keyframes fadeIn {
	0% {
	  opacity: 0;
	  visibility: visible;
	}
	25% {
	  opacity: 0.1875;
	}
	100% {
	  visibility: visible;
	}
}
```

Voilà!